### PR TITLE
Allow setting Poetry version from a .poetry_version file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,15 @@ heroku config:set PYTHON_RUNTIME_VERSION=3.9.1
 
 ### Poetry
 
-Poetry version can be specified by setting `POETRY_VERSION` in Heroku config vars. Otherwise, it will default to a hardcoded version.
+If the deployed repository has a .poetry_version file at the root containing a version number, this will be used as the version of Poetry. Example:
 
-```
-heroku config:set POETRY_VERSION=1.1.13
-```
+$ echo '2.12.0' > .poetry_version
+$ git add .poetry_version
+$ git commit -m "Set Poetry version"
+
+Alternately, set the POETRY_VERSION environment variable to the desired version.
+If both are present, the environment variable will be used.
+If none is present, it will default to a hardcoded version.
 
 Generally all variables starting with `POETRY_` are passed on to Poetry by this buildpack; see the corresponding [Poetry documentation](https://python-poetry.org/docs/configuration/#using-environment-variables) section for possible uses.
 

--- a/bin/compile
+++ b/bin/compile
@@ -27,12 +27,21 @@ for env_file in $BUILDPACK_VARIABLES ; do
     [ -f "$ENV_DIR/$env_file" ] && export "$(basename "$env_file")=$(cat "$ENV_DIR/$env_file" 2>/dev/null)"
 done
 
-if [ -z "${POETRY_VERSION:-}" ] ; then
+if [ -f "$ENV_DIR/POETRY_VERSION" ]; then
+  POETRY_VERSION=$(cat "$ENV_DIR/POETRY_VERSION")
+  echo "--> Found POETRY_VERSION variable, using version: $POETRY_VERSION"
+else
+  if [ -f "$BUILD_DIR/.poetry_version" ]; then
+    POETRY_VERSION=$(cat "$BUILD_DIR/.poetry_version")
+    echo "--> Found .poetry_version file, using version: $POETRY_VERSION"
+  else
     export POETRY_VERSION=1.2.2
     log "No Poetry version specified in POETRY_VERSION config var. Defaulting to $POETRY_VERSION."
-else
-    log "Using Poetry version from POETRY_VERSION config var: $POETRY_VERSION"
+  fi
 fi
+
+# Tolerate, but don't require, a 'v' prefix in the version
+POETRY_VERSION=${POETRY_VERSION#v}
 
 log "Generate requirements.txt with Poetry"
 


### PR DESCRIPTION
This Pull Request aims to add the ability to use use a `.poetry_version` file to specify Poetry version to be used.

It first try to load Poetry version from environment variable `POETRY_VERSION`.
If the variable is not set, it will try to load it from `.poetry_version`.
If the file is not found, it will then default to a hardcoded Poetry version (same behavior as current one).
